### PR TITLE
fix channel slider labels

### DIFF
--- a/components/options.js
+++ b/components/options.js
@@ -53,7 +53,7 @@ const Options = () => {
                         min={0}
                         max={maxChannels}
                         stepSize={1}
-                        labelStepSize={maxChannels / 10}
+                        labelStepSize={Math.max(1, maxChannels / 10)}
                         onChange={(value) => setOption('slices', value)}
                         value={options.slices}
                         disabled={disabled}


### PR DESCRIPTION
If there were less than 10 channels some numbers would repeat in the labels resulting in an awkward design and user experience. This commit fixes this problem by adding a simple check.